### PR TITLE
Small bugs I noticed

### DIFF
--- a/frameAxis.py
+++ b/frameAxis.py
@@ -11,12 +11,14 @@ class FrameAxis:
     def __init__(self, mfd=None, w2v_model=None):
 
         self.model = w2v_model
-        self.vocab = self.model.wv.vocab
+        self.vocab = self.model.vocab
         if mfd == "emfd":
             emfd = pd.read_csv(
-                'molar_foundation_dictionaries/eMFD_wordlist.csv')
+                'moral_foundation_dictionaries/eMFD_wordlist.csv')
             self.axes, mfs = self._get_emfd_axes(emfd)
         elif mfd == "mfd":
+            mfd = pd.read_csv(
+                'moral_foundations_dictionaries/MFD_orignial.csv')
             self.axes, mfs = self._get_axes(mfd)
         # todo add "mfd2"
         self.cos_sim_dict = {'authority': {}, 'fairness': {}, 'general_morality': {}, 'harm': {}, 'ingroup': {},


### PR DESCRIPTION
Hi Negar, as I was running your code I found a couple small things:
1. in line #14, you had `self.vocab = self.model.wv.vocab`, but I got: AttributeError: 'KeyedVectors' object has no attribute 'wv'. When I removed `.wv` everything is fine.
2. There's a typo "molar" which should be "moral" on line 17
3. In lines 19 - 20 I think you forgot to read the mfd file? So I added that on temporarily, otherwise variable `mfd` is a string and I got error. 
4. Also, still about the mfd file, even after reading the `moral_foundation_dictionaries/MFD_original.csv`, there's still error in line 50: KeyError: 'mf'. I saw that there's no `mf` column in this csv. Maybe you uploaded the wrong csv for mfd?

Fiona