### PR TITLE
Stripping trailing characters to address issue 5

### DIFF
--- a/frameAxis.py
+++ b/frameAxis.py
@@ -275,6 +275,7 @@ class FrameAxis:
     def get_fa_scores(self, df, doc_colname, save_path=None, tfidf=False,
                       format="virtue_vice"):
         df = df.reset_index(drop=True)
+        df.columns = [i.rstrip() for i in df.columns]
         docs = df[doc_colname]
         print(f'Preprocessing column {doc_colname}')
         docs = preprocess(docs).reset_index(drop=True)


### PR DESCRIPTION
I encountered the same issue as @fishfree when trying to add scores to a csv file with only one comment. The issue appears to be due to trailing carriage return ('\r') getting added to the last column of a csv file. This may be limited to Windows or specific type of environment @fishfree and I have, but it may be useful to strip trailing characters from column names of the dataframe to prevent this and similar issues (where column name in the file does not correspond to the argument provided upon execution).   